### PR TITLE
fix an issue with order of timeseries

### DIFF
--- a/gents/hfcollection.py
+++ b/gents/hfcollection.py
@@ -62,7 +62,7 @@ def find_files(head_path, pattern):
             if fnmatch.fnmatch(file, pattern):
                 matched_files.append(Path(os.path.join(root, file)))
 
-    return matched_files
+    return sorted(matched_files)
 
 
 def calculate_year_slices(slice_size_years, min_year, max_year):


### PR DESCRIPTION
Fixes issue #3 ordering the list of files will cause the timeseries to be read and written in the correct order.
