### PR TITLE
Added patch for handling of missing time_bounds and support for Dask-less install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,12 @@ FROM python:3.11-slim
 
 WORKDIR /project
 
-COPY pyproject.toml requirements.txt ./
-
-RUN pip install --upgrade pip
-RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install pytest sphinx sphinx-autobuild
-
 COPY . .
 
-RUN pip install -e .
+RUN pip install --upgrade pip
+RUN pip install pytest sphinx sphinx-autobuild
+
+RUN pip install -e .[parallel]
 
 EXPOSE 8000
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ The GenTS (Generate Time Series) is an open-source Python Package designed to si
 GenTS can be installed using `pip`:
 
 ```
-pip install gents
+pip install gents['parallel']
 ```
+
+Although it is reccomended to use the Dask implementation, you may wish to implement your own parallel solution for large datasets. If you then don't want to include Dask in your installation, you may omit `['parallel']` from the command (this limits GenTS to only run in serial).
 
 To install from source, please view the [ReadTheDocs Documentation](https://gents.readthedocs.io/en/latest/).
 
@@ -27,6 +29,24 @@ from dask.distributed import LocalCluster, Client
 
 cluster = LocalCluster(n_workers=30, threads_per_worker=1, memory_limit="2GB")
 client = cluster.get_client()
+
+input_head_dir = "... case directory with model output ..."
+output_head_dir = "... scratch directory to output time series to ..."
+
+hf_collection = HFCollection(input_head_dir)
+hf_collection = hf_collection.include_patterns(["*/atm/*", "*/ocn/*", "*.h4.*"])
+hf_collection.pull_metadata()
+
+ts_collection = TSCollection(hf_collection.include_years(0, 5), output_head_dir)
+ts_collection = ts_collection.apply_overwrite("*")
+ts_collection.execute()
+```
+
+The serial equivalent (without Dask) is the same, just without the Dask `Client` or `LocalCluster`:
+
+```
+from gents.hfcollection import HFCollection
+from gents.timeseries import TSCollection
 
 input_head_dir = "... case directory with model output ..."
 output_head_dir = "... scratch directory to output time series to ..."

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -10,6 +10,12 @@ Pip can be used to easily install GenTS along with all of its dependencies in an
 
 .. code-block:: console
 
+    pip install gents['parallel']
+
+If you only wish to have the serial version of GenTS (without Dask for parallel computing), you can omit the ``['parallel']`` optional dependency group:
+
+.. code-block:: console
+
     pip install gents
 
 
@@ -27,4 +33,10 @@ Then install the package locally using ``pip``.
 
 .. code-block:: console
 
-    pip install -e .
+    pip install -e .['parallel']
+
+Alternatively, you can build the Docker image and run a virtual Python environment with only GenTS and its full dependencies installed:
+
+.. code-block:: console
+    docker build -t gents:latest .
+    docker run --rm -it -v .:/project gents python

--- a/docs/user.rst
+++ b/docs/user.rst
@@ -24,7 +24,7 @@ The GenTS (Generate Time Series) is an open-source Python Package designed to si
     ts_collection.execute()
 
 
-The bulk of functionality in this package is provided by two Python classes: ``gents.hfcollection.HFCollection`` and ``gents.timeseries.TSCollection``. These classes centralize the organization of history files and provides an interface for customizing time series output through sequences of operations. In general, the user begins by spinning up a Dask cluster and then defining a ``HFCollection`` which searches recursivelhttps://cfconventions.org/y through a directory structure for history files. The user can then optionally apply filters to the selection to include only specific history file types. Once the desired history files have been identified, the class object automatically groups them by sub-directory and file name patterns. The user then creates a ``TSCollection`` from the populated ``HFCollection`` which organizes the history file groupings into a list of Dask delayed function calls that can be sent to a cluster for distributed computing.
+The bulk of functionality in this package is provided by two Python classes: ``gents.hfcollection.HFCollection`` and ``gents.timeseries.TSCollection``. These classes centralize the organization of history files and provides an interface for customizing time series output through sequences of operations. In general, the user begins by spinning up a Dask cluster and then defining a ``HFCollection`` which searches recursively through a directory structure for history files. The user can then optionally apply filters to the selection to include only specific history file types. Once the desired history files have been identified, the class object automatically groups them by sub-directory and file name patterns. The user then creates a ``TSCollection`` from the populated ``HFCollection`` which organizes the history file groupings into a list of Dask delayed function calls that can be sent to a cluster for distributed computing.
 
 Creating a Dask Cluster
 -----------------------
@@ -140,7 +140,7 @@ Just like with ``HFCollection``, both ``TSCollection.include`` and ``TSCollectio
     ts_h2_temps_only = ts_collection.include(path_glob="*.h2.*", var_glob="T*")
     ts_h2_temps_no_pop = ts_h2_only.exclude(path_glob="*.pop.*", var_glob="*")
 
-Once filtered, custom arguments can be applied to all time series or just a subset. Currently supported arguments include whether to overwrite existing time series, compression level, and compression algorithm. These arguments are passed to the ``netCDF4 Python API <https://unidata.github.io/netcdf4-python/>``_. The arguments can be applied using glob patterns for both paths and variable names:
+Once filtered, custom arguments can be applied to all time series or just a subset. Currently supported arguments include whether to overwrite existing time series, compression level, and compression algorithm. These arguments are passed to the `netCDF4 Python API <https://unidata.github.io/netcdf4-python/>`_. The arguments can be applied using glob patterns for both paths and variable names:
 
 .. code-block:: python
 

--- a/gents/hfcollection.py
+++ b/gents/hfcollection.py
@@ -217,7 +217,7 @@ def is_ds_within_years(ds_meta, min_year, max_year):
     :param max_year: Maximum year in range.
     :return: True if time bounds are within the year range, false if not.
     """
-    time_bounds = ds_meta.get_cftime_bounds()[0]
+    time_bounds = ds_meta.get_cftime_bounds()
     if time_bounds is not None:
         year = (time_bounds[0].year + time_bounds[1].year) / 2
     else:
@@ -502,7 +502,7 @@ class HFCollection:
                 if fnmatch.fnmatch(path, pattern):
                     meta_ds = filtered_path_map[path]
                     if meta_ds.get_cftime_bounds() is not None:
-                        avg_year = np.mean([ts.year for ts in meta_ds.get_cftime_bounds()])
+                        avg_year = np.mean([ts.year for ts in meta_ds.get_cftime_bounds()[0]])
                     else:
                         avg_year = np.mean([ts.year for ts in meta_ds.get_cftimes()])
                     
@@ -557,9 +557,9 @@ class HFCollection:
                 variable_set = None
                 for hf_path in hf_paths:
                     meta_ds = self.__hf_to_meta_map[hf_path]
-                    time_bnds = meta_ds.get_cftime_bounds()
         
-                    if time_bnds is not None:
+                    if meta_ds.get_cftime_bounds() is not None:
+                        time_bnds = meta_ds.get_cftime_bounds()[0]
                         time = time_bnds[0] + (time_bnds[1] - time_bnds[0]) / 2
                     else:
                         time = meta_ds.get_cftimes()[0]

--- a/gents/hfcollection.py
+++ b/gents/hfcollection.py
@@ -8,7 +8,6 @@ Last Header Update: 04/30/25
 """
 from gents.meta import get_meta_from_path
 from gents.utils import ProgressBar
-from dask.distributed import client
 from cftime import num2date
 from pathlib import Path
 import numpy as np
@@ -16,12 +15,19 @@ import os
 import fnmatch
 import cftime
 import netCDF4
-import dask
 import warnings
 import logging
 
 logging.captureWarnings(True)
 logger = logging.getLogger(__name__)
+
+try:
+    from dask.distributed import client
+    import dask
+    DASK_INSTALLED = True
+except ImportError:
+    DASK_INSTALLED = False
+    logger.debug("Dask not installed. Proceeding in serial.")
 
 
 def check_config(config):
@@ -327,7 +333,7 @@ class HFCollection:
         """
         self.__raw_paths = find_files(hf_dir, "*.nc")
 
-        if dask_client is None:
+        if dask_client is None and DASK_INSTALLED:
             self.__client = dask.distributed.client._get_global_client()
         else:
             self.__client = dask_client

--- a/gents/hfcollection.py
+++ b/gents/hfcollection.py
@@ -218,7 +218,10 @@ def is_ds_within_years(ds_meta, min_year, max_year):
     :return: True if time bounds are within the year range, false if not.
     """
     time_bounds = ds_meta.get_cftime_bounds()[0]
-    year = (time_bounds[0].year + time_bounds[1].year) / 2
+    if time_bounds is not None:
+        year = (time_bounds[0].year + time_bounds[1].year) / 2
+    else:
+        year = ds_meta.get_cftimes()[0]
 
     if min_year <= year <= max_year:
         return True
@@ -498,7 +501,10 @@ class HFCollection:
             for path in filtered_path_map:
                 if fnmatch.fnmatch(path, pattern):
                     meta_ds = filtered_path_map[path]
-                    avg_year = np.mean([ts[0].year for ts in meta_ds.get_cftime_bounds()])
+                    if meta_ds.get_cftime_bounds() is not None:
+                        avg_year = np.mean([ts.year for ts in meta_ds.get_cftime_bounds()])
+                    else:
+                        avg_year = np.mean([ts.year for ts in meta_ds.get_cftimes()])
                     
                     if not start_year <= avg_year <= end_year:
                         remove_paths.append(path)
@@ -551,7 +557,7 @@ class HFCollection:
                 variable_set = None
                 for hf_path in hf_paths:
                     meta_ds = self.__hf_to_meta_map[hf_path]
-                    time_bnds = meta_ds.get_cftime_bounds()[0]
+                    time_bnds = meta_ds.get_cftime_bounds()
         
                     if time_bnds is not None:
                         time = time_bnds[0] + (time_bnds[1] - time_bnds[0]) / 2

--- a/gents/meta.py
+++ b/gents/meta.py
@@ -69,6 +69,8 @@ class netCDFMeta:
         """
         :param ds: netCDF dataset read of history file (not this is not the path).
         """
+        self.__time_vals = None
+        self.__cftime_vals = None
         try:
             if 'time' in ds.variables:
                 self.__time_vals = ds['time'][:]
@@ -76,29 +78,27 @@ class netCDFMeta:
             else:
                 logger.warning(f"Unable to find 'time' variable.")
         except AttributeError:
-            self.__time_vals = None
-            self.__cftime_vals = None
             logger.warning(f"Unable to pull 'calendar' and/or 'units' attributes from 'time' variable.")
 
+        self.__time_bounds_vals = None
+        self.__cftime_bounds_vals = None
         try:
             if 'time_bnds' in ds.variables:
                 self.__time_bounds_vals = ds['time_bnds'][:]
-                self.__cftime_bounds_vals = num2date(ds['time_bnds'][:], units=ds["time"].units, calendar=ds["time"].calendar)
+                self.__cftime_bounds_vals = num2date(ds['time_bnds'][:], units=ds["time_bnds"].units, calendar=ds["time_bnds"].calendar)
             elif 'time_bnd' in ds.variables:
                 self.__time_bounds_vals = ds['time_bnd'][:]
-                self.__cftime_bounds_vals = num2date(ds['time_bnd'][:], units=ds["time"].units, calendar=ds["time"].calendar)
+                self.__cftime_bounds_vals = num2date(ds['time_bnd'][:], units=ds["time_bnd"].units, calendar=ds["time_bnd"].calendar)
             elif 'time_bounds' in ds.variables:
                 self.__time_bounds_vals = ds['time_bounds'][:]
-                self.__cftime_bounds_vals = num2date(ds['time_bounds'][:], units=ds["time"].units, calendar=ds["time"].calendar)
+                self.__cftime_bounds_vals = num2date(ds['time_bounds'][:], units=ds["time_bounds"].units, calendar=ds["time_bounds"].calendar)
             elif 'time_bound' in ds.variables:
                 self.__time_bounds_vals = ds['time_bound'][:]
-                self.__cftime_bounds_vals = num2date(ds['time_bound'][:], units=ds["time"].units, calendar=ds["time"].calendar)
+                self.__cftime_bounds_vals = num2date(ds['time_bound'][:], units=ds["time_bound"].units, calendar=ds["time_bound"].calendar)
             else:
-                logger.warning(f"Unable to find equivalent 'time bounds' variable.")
+                logger.warning(f"Unable to find equivalent 'time bounds' variable. Defaulting to 'time'.")
         except AttributeError:
-            self.__time_bounds_vals = None
-            self.__cftime_bounds_vals = None
-            logger.warning(f"Unable to pull 'calendar' and/or 'units' attributes from 'time bounds' equivalent variable.")
+            logger.warning(f"Unable to pull 'calendar' and/or 'units' attributes from 'time_bounds' equivalent variable.")
 
         self.__var_names = list(ds.variables)
         self.__primary_var_names = []
@@ -171,7 +171,7 @@ class netCDFMeta:
         """
         :return: Whether or not all necessary information is available for GenTS to create a time series.
         """
-        if self.get_cftime_bounds() is None:
+        if self.get_cftime_bounds() is None and self.get_cftimes() is None:
             return False
         elif len(self.get_primary_variables()) == 0:
             return False

--- a/gents/tests/test_cases.py
+++ b/gents/tests/test_cases.py
@@ -47,15 +47,16 @@ def generate_history_file(path, time_val, time_bounds_val, num_vars=SIMPLE_NUM_V
         "long_name": "time"
     })
 
-    time_bnds_data = ds.createVariable(f"time_bounds", np.double, ("time", "bnds"))
-    time_bnds_data[:] = [time_bounds_val]
-    time_bnds_data.setncatts({
-        "calendar": "360_day",
-        "units": "days since 1850-01-01",
-        "standard_name": "time_bounds",
-        "long_name": "time_bounds"
-    })
-    
+    if time_bounds_val is not None:
+        time_bnds_data = ds.createVariable(f"time_bounds", np.double, ("time", "bnds"))
+        time_bnds_data[:] = [time_bounds_val]
+        time_bnds_data.setncatts({
+            "calendar": "360_day",
+            "units": "days since 1850-01-01",
+            "standard_name": "time_bounds",
+            "long_name": "time_bounds"
+        })
+        
     ds.setncatts({
         "source": "GenTS testing suite",
         "description": "Synthetic data used for testing with the GenTS package.",
@@ -105,4 +106,16 @@ def structured_case(tmp_path_factory):
             for file_index in range(STRUCTURED_NUM_TEST_HIST_FILES):
                 path = f"{dir_path}/testing.hf.{str(file_index).zfill(5)}.nc" 
                 generate_history_file(path, (file_index+1)*30, [file_index*30, (file_index+1)*30], num_vars=SCRAMBLED_NUM_VARS)
+    return head_hf_dir, head_ts_dir
+
+
+@pytest.fixture(scope="function")
+def no_time_bounds_case(tmp_path_factory):
+    head_hf_dir = tmp_path_factory.mktemp("no_tb_history_files")
+    head_ts_dir = tmp_path_factory.mktemp("no_tb_timeseries_files")
+    
+    hf_paths = [f"{head_hf_dir}/testing.hf.{str(index).zfill(5)}.nc" for index in range(SIMPLE_NUM_TEST_HIST_FILES)]
+    for file_index, path in enumerate(hf_paths):
+        generate_history_file(path, (file_index+1)*30, None)
+
     return head_hf_dir, head_ts_dir

--- a/gents/tests/test_cases.py
+++ b/gents/tests/test_cases.py
@@ -49,7 +49,7 @@ def generate_history_file(path, time_val, time_bounds_val, num_vars=SIMPLE_NUM_V
 
     if time_bounds_val is not None:
         time_bnds_data = ds.createVariable(f"time_bounds", np.double, ("time", "bnds"))
-        time_bnds_data[:] = [time_bounds_val]
+        time_bnds_data[:] = time_bounds_val
         time_bnds_data.setncatts({
             "calendar": "360_day",
             "units": "days since 1850-01-01",
@@ -73,7 +73,7 @@ def simple_case(tmp_path_factory):
     
     hf_paths = [f"{head_hf_dir}/testing.hf.{str(index).zfill(5)}.nc" for index in range(SIMPLE_NUM_TEST_HIST_FILES)]
     for file_index, path in enumerate(hf_paths):
-        generate_history_file(path, (file_index+1)*30, [file_index*30, (file_index+1)*30])
+        generate_history_file(path, [(file_index+1)*30], [[file_index*30, (file_index+1)*30]])
 
     return head_hf_dir, head_ts_dir
 
@@ -89,7 +89,7 @@ def scrambled_case(tmp_path_factory):
     random.shuffle(hf_paths)
     
     for file_index, path in enumerate(hf_paths):
-        generate_history_file(path, (file_index+1)*30, [file_index*30, (file_index+1)*30], num_vars=SCRAMBLED_NUM_VARS)
+        generate_history_file(path, [(file_index+1)*30], [[file_index*30, (file_index+1)*30]], num_vars=SCRAMBLED_NUM_VARS)
     return head_hf_dir, head_ts_dir
     
 
@@ -105,7 +105,7 @@ def structured_case(tmp_path_factory):
             
             for file_index in range(STRUCTURED_NUM_TEST_HIST_FILES):
                 path = f"{dir_path}/testing.hf.{str(file_index).zfill(5)}.nc" 
-                generate_history_file(path, (file_index+1)*30, [file_index*30, (file_index+1)*30], num_vars=SCRAMBLED_NUM_VARS)
+                generate_history_file(path, [(file_index+1)*30], [[file_index*30, (file_index+1)*30]], num_vars=SCRAMBLED_NUM_VARS)
     return head_hf_dir, head_ts_dir
 
 
@@ -116,6 +116,6 @@ def no_time_bounds_case(tmp_path_factory):
     
     hf_paths = [f"{head_hf_dir}/testing.hf.{str(index).zfill(5)}.nc" for index in range(SIMPLE_NUM_TEST_HIST_FILES)]
     for file_index, path in enumerate(hf_paths):
-        generate_history_file(path, (file_index+1)*30, None)
+        generate_history_file(path, [(file_index+1)*30], None)
 
     return head_hf_dir, head_ts_dir

--- a/gents/tests/test_dask.py
+++ b/gents/tests/test_dask.py
@@ -1,15 +1,16 @@
-from dask.distributed import LocalCluster, Client
 from gents.hfcollection import HFCollection
 from gents.timeseries import TSCollection
 from test_cases import *
 from test_workflow import is_monotonic
 from netCDF4 import Dataset
+from pytest import importorskip
 
 
 def test_dask_simple_workflow(simple_case):
+    daskd = importorskip("dask.distributed", reason="Dask distributed not installed.")
     input_head_dir, output_head_dir = simple_case
 
-    cluster = LocalCluster(n_workers=2, threads_per_worker=1, memory_limit="2GB")
+    cluster = daskd.LocalCluster(n_workers=2, threads_per_worker=1, memory_limit="2GB")
     client = cluster.get_client()
 
     hf_collection = HFCollection(input_head_dir, dask_client=client)
@@ -39,9 +40,10 @@ def test_dask_simple_workflow(simple_case):
 
 
 def test_dask_scrambled_workflow(scrambled_case):
+    daskd = importorskip("dask.distributed", reason="Dask distributed not installed.")
     input_head_dir, output_head_dir = scrambled_case
 
-    cluster = LocalCluster(n_workers=2, threads_per_worker=1, memory_limit="2GB")
+    cluster = daskd.LocalCluster(n_workers=2, threads_per_worker=1, memory_limit="2GB")
     client = cluster.get_client()
 
     hf_collection = HFCollection(input_head_dir, dask_client=client)
@@ -61,9 +63,10 @@ def test_dask_scrambled_workflow(scrambled_case):
 
 
 def test_dask_structured_workflow(structured_case):
+    daskd = importorskip("dask.distributed", reason="Dask distributed not installed.")
     input_head_dir, output_head_dir = structured_case
 
-    cluster = LocalCluster(n_workers=2, threads_per_worker=1, memory_limit="2GB")
+    cluster = daskd.LocalCluster(n_workers=2, threads_per_worker=1, memory_limit="2GB")
     client = cluster.get_client()
 
     hf_collection = HFCollection(input_head_dir, dask_client=client)

--- a/gents/timeseries.py
+++ b/gents/timeseries.py
@@ -9,7 +9,6 @@ Last Header Update: 01/31/25
 import netCDF4
 import numpy as np
 import fnmatch
-import dask
 from os.path import isfile
 from os import remove, makedirs
 from cftime import num2date
@@ -19,6 +18,14 @@ from gents.utils import get_version, ProgressBar
 import logging
 
 logger = logging.getLogger(__name__)
+
+try:
+    import dask
+    DASK_INSTALLED = True
+except ImportError:
+    DASK_INSTALLED = False
+    logger.debug("Dask not installed. Proceeding in serial.")
+
 
 def get_timestamp_str(times):
     """
@@ -171,7 +178,7 @@ class TSCollection:
         :param ts_orders: List of Dask delayed functions of generate_time_series
         :param dask_client: Dask client to use when executing time series batches (Default: global client).
         """
-        if dask_client is None:
+        if dask_client is None and DASK_INSTALLED:
             self.__dask_client = dask.distributed.client._get_global_client()
         else:
             self.__dask_client = dask_client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm", "numpy", "dask", "netCDF4", "cftime"]
+requires = ["setuptools", "setuptools-scm", "numpy", "netCDF4", "cftime"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "GenTS"
-version = "0.9.0"
+version = "0.9.1"
 authors = [
   { name="Cameron Cummins", email="cameron.cummins@utexas.edu" },
 ]
@@ -14,7 +14,6 @@ requires-python = ">=3.10.13"
 dependencies = [
   "numpy",
   "netcdf4",
-  "dask",
   "cftime"
 ]
 classifiers = [
@@ -29,3 +28,6 @@ Issues = "https://github.com/AgentOxygen/GenTS"
 
 [tool.setuptools]
 packages = ["gents"]
+
+[project.optional-dependencies]
+parallel = ["dask[distributed]"]


### PR DESCRIPTION
This allows GenTS to handle history files that do not have a time_bounds variable (or equivalent variable)